### PR TITLE
Allow defining Swagger + SecurityScheme annotations

### DIFF
--- a/Describer/SwaggerPhpDescriber.php
+++ b/Describer/SwaggerPhpDescriber.php
@@ -126,7 +126,7 @@ final class SwaggerPhpDescriber extends ExternalDocDescriber implements ModelReg
                     continue;
                 }
 
-                if (!$annotation instanceof SWG\Response && !$annotation instanceof SWG\Parameter && !$annotation instanceof SWG\ExternalDocumentation) {
+                if (!$annotation instanceof SWG\Response && !$annotation instanceof SWG\Parameter && !$annotation instanceof SWG\ExternalDocumentation && !$annotation instanceof SWG\Swagger) {
                     throw new \LogicException(sprintf('Using the annotation "%s" as a root annotation in "%s::%s()" is not allowed.', get_class($annotation), $method->getDeclaringClass()->name, $method->name));
                 }
 


### PR DESCRIPTION
    /*
     * @SWG\Swagger(
     *     @SWG\SecurityScheme(
     *         securityDefinition="coreAuth",
     *         type="oauth2",
     *         flow="password",
     *         tokenUrl="http://smartum-core.dev/oauth/v2/token",
     *         scopes={"protected"="Protected resource"}
     *     )
     * )
     */